### PR TITLE
Updates existsSync to return Boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ module.exports.copyFileSync = function(path, dest, flags) {
 
 module.exports.existsSync = function(path) {
   var fileManager = NSFileManager.defaultManager()
-  return fileManager.fileExistsAtPath(path)
+  return Boolean(fileManager.fileExistsAtPath(path))
 }
 
 module.exports.linkSync = function(existingPath, newPath) {


### PR DESCRIPTION
Minor change, but helpful in reducing confusion around `existsSync` and making it follow [Node's `fs.existsSync`](https://nodejs.org/api/fs.html#fs_fs_existssync_path)