### PR TITLE
Match node.js API and allow for recursive creation in mkdirSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,8 +182,14 @@ module.exports.linkSync = function(existingPath, newPath) {
 }
 
 module.exports.mkdirSync = function(path, options) {
-  var mode = options.mode || 0o777
-  var recursive = options.recursive || false
+  var mode = 0o777
+  var recursive = false
+  if (typeof options === "number") {
+    mode = options
+  } else if (typeof options === "object") {
+    mode = options.mode
+    recursive = options.recursive
+  }
   var err = MOPointer.alloc().init()
   var fileManager = NSFileManager.defaultManager()
   fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, recursive, {

--- a/index.js
+++ b/index.js
@@ -181,11 +181,11 @@ module.exports.linkSync = function(existingPath, newPath) {
   }
 }
 
-module.exports.mkdirSync = function(path, mode) {
+module.exports.mkdirSync = function(path, { recursive, mode }) {
   mode = mode || 0o777
   var err = MOPointer.alloc().init()
   var fileManager = NSFileManager.defaultManager()
-  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, false, {
+  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, recursive, {
     NSFilePosixPermissions: mode
   }, err)
 

--- a/index.js
+++ b/index.js
@@ -184,11 +184,14 @@ module.exports.linkSync = function(existingPath, newPath) {
 module.exports.mkdirSync = function(path, options) {
   var mode = 0o777
   var recursive = false
+  if (options && options.mode) {
+    mode = options.mode
+  }
+  if (options && options.recursive) {
+    recursive = options.recursive
+  }
   if (typeof options === "number") {
     mode = options
-  } else if (typeof options === "object") {
-    mode = options.mode
-    recursive = options.recursive
   }
   var err = MOPointer.alloc().init()
   var fileManager = NSFileManager.defaultManager()

--- a/index.js
+++ b/index.js
@@ -181,11 +181,11 @@ module.exports.linkSync = function(existingPath, newPath) {
   }
 }
 
-module.exports.mkdirSync = function(path, { recursive, mode }) {
-  mode = mode || 0o777
+module.exports.mkdirSync = function(path, options) {
+  mode = options.mode || 0o777
   var err = MOPointer.alloc().init()
   var fileManager = NSFileManager.defaultManager()
-  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, recursive, {
+  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, options.recursive, {
     NSFilePosixPermissions: mode
   }, err)
 

--- a/index.js
+++ b/index.js
@@ -182,10 +182,11 @@ module.exports.linkSync = function(existingPath, newPath) {
 }
 
 module.exports.mkdirSync = function(path, options) {
-  mode = options.mode || 0o777
+  var mode = options.mode || 0o777
+  var recursive = options.recursive || false
   var err = MOPointer.alloc().init()
   var fileManager = NSFileManager.defaultManager()
-  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, options.recursive, {
+  fileManager.createDirectoryAtPath_withIntermediateDirectories_attributes_error(path, recursive, {
     NSFilePosixPermissions: mode
   }, err)
 


### PR DESCRIPTION
This is a breaking change, because currently `mkdirSync` takes an integer (permissions mode) as its second argument. To better match the [Node API](
https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options), we should make the second parameter an `options` parameter, and extract `mode` and `recursive` from it. `recursive` can then be supplied to `createDirectoryAtPath_withIntermediateDirectories_attributes_error`.